### PR TITLE
Added toggle feature + data type omission functionality

### DIFF
--- a/Prisma.xcodeproj/project.pbxproj
+++ b/Prisma.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */; };
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
+		AC69903E2B6C5A2F00D92970 /* PrivacyControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC69903D2B6C5A2F00D92970 /* PrivacyControls.swift */; };
+		AC6990402B6C627100D92970 /* ToggleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC69903F2B6C627100D92970 /* ToggleTestView.swift */; };
 		F8AF6F9A2B5F2B1A0011C32D /* AppIcon-NoBG.png in Resources */ = {isa = PBXBuildFile; fileRef = F8AF6F992B5F2B1A0011C32D /* AppIcon-NoBG.png */; };
 		F8AF6F9F2B5F35400011C32D /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AF6F9E2B5F35400011C32D /* ChatView.swift */; };
 		F8AF6FA52B5F3AE70011C32D /* EventContextCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AF6FA42B5F3AE70011C32D /* EventContextCard.swift */; };
@@ -146,6 +148,8 @@
 		A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupHeader.swift; sourceTree = "<group>"; };
 		A9DFE8A82ABE551400428242 /* AccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButton.swift; sourceTree = "<group>"; };
 		A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
+		AC69903D2B6C5A2F00D92970 /* PrivacyControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyControls.swift; sourceTree = "<group>"; };
+		AC69903F2B6C627100D92970 /* ToggleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleTestView.swift; sourceTree = "<group>"; };
 		F8AF6F992B5F2B1A0011C32D /* AppIcon-NoBG.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-NoBG.png"; sourceTree = "<group>"; };
 		F8AF6F9E2B5F35400011C32D /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F8AF6FA42B5F3AE70011C32D /* EventContextCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContextCard.swift; sourceTree = "<group>"; };
@@ -390,6 +394,8 @@
 		AC4A1ED12B69D91D0095D1AE /* PrivacyControls */ = {
 			isa = PBXGroup;
 			children = (
+				AC69903D2B6C5A2F00D92970 /* PrivacyControls.swift */,
+				AC69903F2B6C627100D92970 /* ToggleTestView.swift */,
 			);
 			path = PrivacyControls;
 			sourceTree = "<group>";
@@ -665,6 +671,8 @@
 				2FE5DC5229EDD7FA004B9AB4 /* PrismaScheduler.swift in Sources */,
 				A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */,
 				F8AF6FB42B5F6EDC0011C32D /* Module.swift in Sources */,
+				AC6990402B6C627100D92970 /* ToggleTestView.swift in Sources */,
+				AC69903E2B6C5A2F00D92970 /* PrivacyControls.swift in Sources */,
 				653A2551283387FE005D4D48 /* Prisma.swift in Sources */,
 				2FE5DC3629EDD7CA004B9AB4 /* HealthKitPermissions.swift in Sources */,
 				5661552E2AB854C000209B80 /* PackageHelper.swift in Sources */,

--- a/Prisma/PrivacyControls/PrivacyControls.swift
+++ b/Prisma/PrivacyControls/PrivacyControls.swift
@@ -1,0 +1,43 @@
+//
+//  PrivacyControls.swift
+//  Prisma
+//
+//  Created by Dhruv Naik on 2/1/24.
+//
+
+import Foundation
+import Spezi
+import SwiftUI
+
+
+@Observable
+public class PrivacyModule: DefaultInitializable, EnvironmentAccessible {
+    var configuration: Configuration {
+        Configuration(standard: PrismaStandard()) { }
+    }
+    var includeStepCountUpload = false
+    var includeActiveEnergyBurned = true
+    var includeDistanceWalkingRunning = true
+    var includeVo2Max = true
+    var includeHeartRate = true
+    var includeRestingHeartRate = true
+    var includeOxygenSaturation = true
+    var includeRespiratoryRate = true
+    var includeWalkingHRAverage = true
+    
+    public required init() {}
+    
+    public func getCurrentToggles() -> [String: Bool] {
+        [
+            "includeStepCountUpload": includeStepCountUpload,
+            "includeActiveEnergyBurned": includeActiveEnergyBurned,
+            "includeDistanceWalkingRunning": includeDistanceWalkingRunning,
+            "includeVo2Max": includeVo2Max,
+            "includeHeartRate": includeHeartRate,
+            "includeRestingHeartRate": includeRestingHeartRate,
+            "includeOxygenSaturation": includeOxygenSaturation,
+            "includeRespiratoryRate": includeRespiratoryRate,
+            "includeWalkingHRAverage": includeWalkingHRAverage
+        ]
+    }
+}

--- a/Prisma/PrivacyControls/PrivacyControls.swift
+++ b/Prisma/PrivacyControls/PrivacyControls.swift
@@ -3,7 +3,10 @@
 //  Prisma
 //
 //  Created by Dhruv Naik on 2/1/24.
+
+//  SPDX-FileCopyrightText: 2023 Stanford University
 //
+//  SPDX-License-Identifier: MIT
 
 import Foundation
 import Spezi

--- a/Prisma/PrivacyControls/ToggleTestView.swift
+++ b/Prisma/PrivacyControls/ToggleTestView.swift
@@ -1,0 +1,36 @@
+//
+//  ToggleTestView.swift
+//  Prisma
+//
+//  Created by Dhruv Naik on 2/1/24.
+//
+import Foundation
+import Spezi
+import SwiftUI
+
+
+struct ToggleTestView: View {
+   @Bindable var privacyModule = PrivacyModule()
+
+    
+    var body: some View {
+        NavigationView {
+                    Form {
+                        Toggle("Include Step Count Upload", isOn: $privacyModule.includeStepCountUpload)
+                        Toggle("Include Active Energy Burned", isOn: $privacyModule.includeActiveEnergyBurned)
+                        Toggle("Include Distance Walking Running", isOn: $privacyModule.includeDistanceWalkingRunning)
+                        Toggle("Include Vo2 Max", isOn: $privacyModule.includeVo2Max)
+                        Toggle("Include Heart Rate", isOn: $privacyModule.includeHeartRate)
+                        Toggle("Include Resting Heart Rate", isOn: $privacyModule.includeRestingHeartRate)
+                        Toggle("Include Oxygen Saturation", isOn: $privacyModule.includeOxygenSaturation)
+                        Toggle("Include Respiratory Rate", isOn: $privacyModule.includeRespiratoryRate)
+                        Toggle("Include Walking Heart Rate Average", isOn: $privacyModule.includeWalkingHRAverage)
+                    }
+                    .navigationBarTitle("Privacy Settings")
+        }
+    }
+}
+
+#Preview {
+    ToggleTestView()
+}

--- a/Prisma/PrivacyControls/ToggleTestView.swift
+++ b/Prisma/PrivacyControls/ToggleTestView.swift
@@ -1,6 +1,9 @@
 //
 //  ToggleTestView.swift
 //  Prisma
+//  SPDX-FileCopyrightText: 2023 Stanford University
+//
+//  SPDX-License-Identifier: MIT
 //
 //  Created by Dhruv Naik on 2/1/24.
 //

--- a/Prisma/Resources/Localizable.xcstrings
+++ b/Prisma/Resources/Localizable.xcstrings
@@ -314,6 +314,33 @@
         }
       }
     },
+    "Include Active Energy Burned" : {
+
+    },
+    "Include Distance Walking Running" : {
+
+    },
+    "Include Heart Rate" : {
+
+    },
+    "Include Oxygen Saturation" : {
+
+    },
+    "Include Respiratory Rate" : {
+
+    },
+    "Include Resting Heart Rate" : {
+
+    },
+    "Include Step Count Upload" : {
+
+    },
+    "Include Vo2 Max" : {
+
+    },
+    "Include Walking Heart Rate Average" : {
+
+    },
     "JAMES_LANDAY_BIO" : {
       "localizations" : {
         "en" : {
@@ -439,6 +466,9 @@
           }
         }
       }
+    },
+    "Privacy Settings" : {
+
     },
     "PROJECT_LICENSE_DESCRIPTION" : {
       "localizations" : {

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -12,6 +12,25 @@ import ModelsR4
 import SpeziFirestore
 import SpeziHealthKit
 
+/*
+ 
+ HKQuantityType(.vo2Max),
+ HKQuantityType(.heartRate),
+ HKQuantityType(.restingHeartRate),
+ HKQuantityType(.oxygenSaturation),
+ HKQuantityType(.respiratoryRate),
+ HKQuantityType(.walkingHeartRateAverage)
+ 
+
+ var includeVo2Max = true
+ var includeHeartRate = true
+ var includeRestingHeartRate = true
+ var includeOxygenSaturation = true
+ var includeRespiratoryRate = true
+ var includeWalkingHRAverage = true
+ */
+
+
 extension PrismaStandard {
     /// Adds a new `HKSample` to the Firestore.
     /// - Parameter response: The `HKSample` that should be added.
@@ -19,6 +38,30 @@ extension PrismaStandard {
         guard let quantityType = sample.sampleType as? HKQuantityType else {
             return
         }
+
+        var sampleToToggleNameMapping: [HKQuantityType?: String] = [
+            HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned): "includeActiveEnergyBurned",
+            HKQuantityType.quantityType(forIdentifier: .stepCount): "includeStepCountUpload",
+            HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning): "includeDistanceWalkingRunning",
+            HKQuantityType.quantityType(forIdentifier: .vo2Max): "includeVo2Max",
+            HKQuantityType.quantityType(forIdentifier: .heartRate): "includeHeartRate",
+            HKQuantityType.quantityType(forIdentifier: .restingHeartRate): "includeRestingHeartRate",
+            HKQuantityType.quantityType(forIdentifier: .oxygenSaturation): "includeOxygenSaturation",
+            HKQuantityType.quantityType(forIdentifier: .respiratoryRate): "includeRespiratoryRate",
+            HKQuantityType.quantityType(forIdentifier: .walkingHeartRateAverage): "includeWalkingHeartRateAverage"
+        ]
+        var toggleNameToBoolMapping: [String: Bool] = PrivacyModule().getCurrentToggles()
+        
+        if let variableName = sampleToToggleNameMapping[quantityType] {
+            let response: Bool = toggleNameToBoolMapping[variableName] ?? false
+            
+            if !response {
+                return
+            }
+        } else {
+            return
+        }
+        
         let path: String
         
         // retrieve id of HKSample (e.g. HKQuantityTypeIdentifierStepCount)


### PR DESCRIPTION
# *Added toggle feature + data type omission functionality*

## :recycle: Current situation & Problem
Current corresponding issue: https://github.com/CS342/2024-Prisma/issues/14
Previously, there was no way for a user to update their preferences for privacy settings depending on the data they want collected. I added a UI view with toggles for the user to select if they no longer want the application to track that data. The state of the toggles are tracked internally, and if the toggle is off, then that specific data type sample does not get sent to firebase. 


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
No additional conformance specifications


## :white_check_mark: Testing
Passes built-in testing and builds properly


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
