### PR TITLE
Chat interface hosting web components

### DIFF
--- a/Prisma.xcodeproj/project.pbxproj
+++ b/Prisma.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */; };
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
+		E4C766262B72D50500C1DEDA /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C766252B72D50500C1DEDA /* WebView.swift */; };
 		F8AF6F9A2B5F2B1A0011C32D /* AppIcon-NoBG.png in Resources */ = {isa = PBXBuildFile; fileRef = F8AF6F992B5F2B1A0011C32D /* AppIcon-NoBG.png */; };
 		F8AF6F9F2B5F35400011C32D /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AF6F9E2B5F35400011C32D /* ChatView.swift */; };
 		F8AF6FA52B5F3AE70011C32D /* EventContextCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AF6FA42B5F3AE70011C32D /* EventContextCard.swift */; };
@@ -146,6 +147,7 @@
 		A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupHeader.swift; sourceTree = "<group>"; };
 		A9DFE8A82ABE551400428242 /* AccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButton.swift; sourceTree = "<group>"; };
 		A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
+		E4C766252B72D50500C1DEDA /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		F8AF6F992B5F2B1A0011C32D /* AppIcon-NoBG.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-NoBG.png"; sourceTree = "<group>"; };
 		F8AF6F9E2B5F35400011C32D /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F8AF6FA42B5F3AE70011C32D /* EventContextCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContextCard.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 			isa = PBXGroup;
 			children = (
 				F8AF6F9E2B5F35400011C32D /* ChatView.swift */,
+				E4C766252B72D50500C1DEDA /* WebView.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				2F4FC8D729EE69D300BFFE26 /* MockUpload.swift in Sources */,
 				2FE5DC3A29EDD7CA004B9AB4 /* Welcome.swift in Sources */,
 				2FE5DC3829EDD7CA004B9AB4 /* Features.swift in Sources */,
+				E4C766262B72D50500C1DEDA /* WebView.swift in Sources */,
 				2FE5DC4529EDD7F2004B9AB4 /* Binding+Negate.swift in Sources */,
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				2FE5DC4E29EDD7FA004B9AB4 /* ScheduleView.swift in Sources */,

--- a/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
+++ b/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
@@ -87,7 +87,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--skipOnboarding"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testSchedule"

--- a/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
+++ b/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
@@ -87,7 +87,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--skipOnboarding"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testSchedule"

--- a/Prisma/Chat/ChatView.swift
+++ b/Prisma/Chat/ChatView.swift
@@ -17,8 +17,9 @@ struct ChatView: View {
     
     var body: some View {
         NavigationStack {
-            if let url = URL(string: "https://www.google.com/") {
+            if let url = URL(string: "http://localhost:3000") {
                 WebView(url: url)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .navigationTitle("chat")
                     .toolbar {
                         if AccountButton.shouldDisplay {

--- a/Prisma/Chat/ChatView.swift
+++ b/Prisma/Chat/ChatView.swift
@@ -14,21 +14,19 @@ import WebKit
 struct ChatView: View {
     @Binding var presentingAccount: Bool
     
-    
     var body: some View {
         NavigationStack {
-            if let url = URL(string: "http://localhost:3000") {
-                WebView(url: url)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .navigationTitle("chat")
-                    .toolbar {
-                        if AccountButton.shouldDisplay {
-                            AccountButton(isPresented: $presentingAccount)
-                        }
-                    }
-                    .edgesIgnoringSafeArea(.bottom)
-            } else {
-                Text("Invalid URL")
+            GeometryReader { geometry in
+                if let url = URL(string: "http://localhost:3000") {
+                    WebView(url: url)
+                        .navigationTitle("Chat")
+                        .frame(
+                            width: geometry.size.width,
+                            height: geometry.size.height
+                        )
+                } else {
+                    Text("Invalid URL")
+                }
             }
         }
     }

--- a/Prisma/Chat/ChatView.swift
+++ b/Prisma/Chat/ChatView.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import WebKit
 
 
 struct ChatView: View {
@@ -16,17 +17,21 @@ struct ChatView: View {
     
     var body: some View {
         NavigationStack {
-            Text("Coming soon!")
-                .navigationTitle("Chat")
-                .toolbar {
-                    if AccountButton.shouldDisplay {
-                        AccountButton(isPresented: $presentingAccount)
+            if let url = URL(string: "https://www.google.com/") {
+                WebView(url: url)
+                    .navigationTitle("chat")
+                    .toolbar {
+                        if AccountButton.shouldDisplay {
+                            AccountButton(isPresented: $presentingAccount)
+                        }
                     }
-                }
+                    .edgesIgnoringSafeArea(.bottom)
+            } else {
+                Text("Invalid URL")
+            }
         }
     }
-    
-    
+
     init(presentingAccount: Binding<Bool>) {
         self._presentingAccount = presentingAccount
     }

--- a/Prisma/Chat/ChatView.swift
+++ b/Prisma/Chat/ChatView.swift
@@ -16,7 +16,7 @@ struct ChatView: View {
     
     var body: some View {
         NavigationStack {
-            if let url = URL(string: "http://localhost:3000/") {
+            if let url = URL(string: "http://localhost:3000") {
                 WebView(url: url)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .navigationTitle("chat")

--- a/Prisma/Chat/ChatView.swift
+++ b/Prisma/Chat/ChatView.swift
@@ -14,10 +14,9 @@ import WebKit
 struct ChatView: View {
     @Binding var presentingAccount: Bool
     
-    
     var body: some View {
         NavigationStack {
-            if let url = URL(string: "http://localhost:3000") {
+            if let url = URL(string: "http://localhost:3000/") {
                 WebView(url: url)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .navigationTitle("chat")

--- a/Prisma/Chat/WebView.swift
+++ b/Prisma/Chat/WebView.swift
@@ -13,7 +13,9 @@ struct WebView: UIViewRepresentable {
     var url: URL
 
     func makeUIView(context: Context) -> WKWebView {
-        WKWebView()
+        let webView = WKWebView(frame: .zero)
+        webView.scrollView.isScrollEnabled = true
+        return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {

--- a/Prisma/Chat/WebView.swift
+++ b/Prisma/Chat/WebView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    var url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        uiView.load(request)
+    }
+}

--- a/Prisma/Chat/WebView.swift
+++ b/Prisma/Chat/WebView.swift
@@ -13,7 +13,7 @@ struct WebView: UIViewRepresentable {
     var url: URL
 
     func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView(frame: .zero)
+        let webView = WKWebView()
         webView.scrollView.isScrollEnabled = true
         return webView
     }

--- a/Prisma/Chat/WebView.swift
+++ b/Prisma/Chat/WebView.swift
@@ -13,7 +13,7 @@ struct WebView: UIViewRepresentable {
     var url: URL
 
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+        WKWebView()
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {

--- a/Prisma/Chat/WebView.swift
+++ b/Prisma/Chat/WebView.swift
@@ -1,3 +1,11 @@
+//
+// This source file is part of the Stanford Prisma Application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
 import SwiftUI
 import WebKit
 

--- a/Prisma/Resources/Localizable.xcstrings
+++ b/Prisma/Resources/Localizable.xcstrings
@@ -76,6 +76,9 @@
         }
       }
     },
+    "chat" : {
+
+    },
     "Chat" : {
 
     },
@@ -89,9 +92,6 @@
           }
         }
       }
-    },
-    "Coming soon!" : {
-
     },
     "Completed at %@" : {
 
@@ -313,6 +313,9 @@
           }
         }
       }
+    },
+    "Invalid URL" : {
+
     },
     "JAMES_LANDAY_BIO" : {
       "localizations" : {


### PR DESCRIPTION
Successfully loaded a web placeholder (google) in chat interface

# *Swift Chat Interface*

## :recycle: Current situation & Problem
*New branch that hosts an interactive React web view within the SwiftUI interface*


## :gear: Release Notes 
*Added WebView under Chat as a SwiftUI Wrapper*
*Modified ChatView under Chat to host desired website. Currently I put localhost for Prisma web as a placeholder, which works.*
`if let url = URL(string: "https://www.google.com/")` 
*Need additional work on formatting.*
1. Chat interface should not zoom in after typing initial message.
2. Ensuring consistency across iPads and iPhones.
3. Next step is implementing user authentication.

## :books: Documentation
*Please reference in-line documentation.* 
<img width="278" alt="image" src="https://github.com/CS342/2024-Prisma/assets/153574461/a233e587-8d99-464e-8902-c5d13fbfa2d7">

## :white_check_mark: Testing
*All tests passed.*
*Additional tests to be added for web performance.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
