### PR TITLE
Create a Timestamp for New Account Creation

### DIFF
--- a/Prisma/Onboarding/AccountOnboarding.swift
+++ b/Prisma/Onboarding/AccountOnboarding.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 struct AccountOnboarding: View {
     @Environment(Account.self) private var account
+    @Environment(PrismaStandard.self) private var standard
     @Environment(OnboardingNavigationPath.self) private var onboardingNavigationPath
     
     
@@ -21,6 +22,7 @@ struct AccountOnboarding: View {
             Task {
                 // Placing the nextStep() call inside this task will ensure that the sheet dismiss animation is
                 // played till the end before we navigate to the next step.
+                await standard.setAccountTimestamp()
                 onboardingNavigationPath.nextStep()
             }
         } header: {

--- a/Prisma/Standard/PrismaStandard.swift
+++ b/Prisma/Standard/PrismaStandard.swift
@@ -147,6 +147,19 @@ actor PrismaStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onbo
         }
         try await accountStorage.create(identifier, details)
     }
+    
+    func setAccountTimestamp() async {
+        // Add a "created_at" timestamp to the newly created user document
+        let timestamp = Timestamp(date: Date())
+        do {
+            try await self.userDocumentReference.setData([
+                "created_at": timestamp
+            ], merge: true)
+            print("Added timestamp to user document")
+        } catch {
+            print("Error updating document: \(error)")
+        }
+    }
 
     func load(_ identifier: AdditionalRecordId, _ keys: [any AccountKey.Type]) async throws -> PartialAccountDetails {
         guard let accountStorage else {


### PR DESCRIPTION
# *Timestamp for New Account Creation*

## :recycle: Current situation & Problem
We are transitioning the backend from a fixed, 15min featurization schedule to a Firestore listener-based schedule (see this [PR](https://github.com/StanfordHCI/prisma/pull/22) for progress). As part of this migration, we have set up a listener on the `studies/STUDY_ID/users` collection to monitor new users. This listener is not triggered by changes to the users collection, as this would trigger on every single data upload to any user. Instead, I propose adding a `created_at` timestamp to each user document, and having the listener trigger on the query: `new_user_query = users_ref.where(filter=FieldFilter('created_at', '>', self.last_query_time))`. 

However, this field is not automatically created for new users. This PR adds functionality to the iOS app to set the field appropriately upon account creation. 

## :gear: Release Notes 
* Added a new function `PrismaStandard.setAccountTimestamp()` that writes the current time to the `created_at` field in the user's document 
* Call `standard.setAccountTimestamp()` in the `AccountOnboarding` continuation

## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 

## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
