### PR TITLE
Adding Sleep and Workout Data

### DIFF
--- a/Prisma/PrismaDelegate.swift
+++ b/Prisma/PrismaDelegate.swift
@@ -74,16 +74,30 @@ class PrismaDelegate: SpeziAppDelegate {
     private var healthKit: HealthKit {
         HealthKit {
             CollectSamples(
+            /// https://developer.apple.com/documentation/healthkit/data_types#2939032
                 [
-                    HKQuantityType(.activeEnergyBurned),
+                    // Activity
                     HKQuantityType(.stepCount),
                     HKQuantityType(.distanceWalkingRunning),
-                    HKQuantityType(.vo2Max),
+                    HKQuantityType(.basalEnergyBurned),
+                    HKQuantityType(.activeEnergyBurned),
+                    HKQuantityType(.flightsClimbed),
+                    HKQuantityType(.appleExerciseTime),
+                    HKQuantityType(.appleMoveTime),
+                    HKQuantityType(.appleStandTime),
+                    
+                    // Vital Signs
                     HKQuantityType(.heartRate),
                     HKQuantityType(.restingHeartRate),
+                    HKQuantityType(.heartRateVariabilitySDNN),
+                    HKQuantityType(.walkingHeartRateAverage),
                     HKQuantityType(.oxygenSaturation),
                     HKQuantityType(.respiratoryRate),
-                    HKQuantityType(.walkingHeartRateAverage)
+                    HKQuantityType(.bodyTemperature),
+                    
+                    // Other events
+                    HKCategoryType(.sleepAnalysis),
+                    HKWorkoutType.workoutType()
                 ],
                 /// predicate to request data from one month in the past to present.
                 predicate: HKQuery.predicateForSamples(

--- a/Prisma/Standard/PrismaStandard+Extension.swift
+++ b/Prisma/Standard/PrismaStandard+Extension.swift
@@ -13,10 +13,15 @@ extension String {
     /// converts a HKSample Type string representation to a lower cased id.
     /// e.g. "HKQuantityTypeIdentifierStepCount" => "stepcount".
     var healthKitDescription: String {
-        let description = self
-        if description.hasPrefix("HKQuantityTypeIdentifier") {
-            // removes the HKQuantityTypeIdentifier prefix.
-            return description.dropFirst(24).lowercased()
+        if self == "workout" {
+            return "workout"
+        }
+        
+        let prefixes = ["HKQuantityTypeIdentifier", "HKCategoryTypeIdentifier", "HKCorrelationTypeIdentifier", "HKWorkoutTypeIdentifier"]
+        for prefix in prefixes {
+            if self.hasPrefix(prefix) {
+                return self.dropFirst(prefix.count).lowercased()
+            }
         }
         return "unknown"
     }

--- a/Prisma/Standard/PrismaStandard+Extension.swift
+++ b/Prisma/Standard/PrismaStandard+Extension.swift
@@ -18,10 +18,8 @@ extension String {
         }
         
         let prefixes = ["HKQuantityTypeIdentifier", "HKCategoryTypeIdentifier", "HKCorrelationTypeIdentifier", "HKWorkoutTypeIdentifier"]
-        for prefix in prefixes {
-            if self.hasPrefix(prefix) {
-                return self.dropFirst(prefix.count).lowercased()
-            }
+        for prefix in prefixes where self.hasPrefix(prefix) {
+            return self.dropFirst(prefix.count).lowercased()
         }
         return "unknown"
     }

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -32,44 +32,63 @@ import SpeziHealthKit
 
 
 extension PrismaStandard {
+    func getSampleIdentifier(sample: HKSample) -> String? {
+        switch sample {
+        case let quantitySample as HKQuantitySample:
+            return quantitySample.quantityType.identifier
+        case let categorySample as HKCategorySample:
+            return categorySample.categoryType.identifier
+        case let workout as HKWorkout:
+            //  return "\(workout.workoutActivityType)"
+            return "workout"
+        // Add more cases for other HKSample subclasses if needed
+        default:
+            return nil
+        }
+    }
+    
     /// Adds a new `HKSample` to the Firestore.
     /// - Parameter response: The `HKSample` that should be added.
     func add(sample: HKSample) async {
-        guard let quantityType = sample.sampleType as? HKQuantityType else {
+        let identifier: String
+        if let id = getSampleIdentifier(sample: sample) {
+            print("Sample identifier: \(id)")
+            identifier = id
+        } else {
+            print("Unknown sample type")
             return
         }
 
-        var sampleToToggleNameMapping: [HKQuantityType?: String] = [
-            HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned): "includeActiveEnergyBurned",
-            HKQuantityType.quantityType(forIdentifier: .stepCount): "includeStepCountUpload",
-            HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning): "includeDistanceWalkingRunning",
-            HKQuantityType.quantityType(forIdentifier: .vo2Max): "includeVo2Max",
-            HKQuantityType.quantityType(forIdentifier: .heartRate): "includeHeartRate",
-            HKQuantityType.quantityType(forIdentifier: .restingHeartRate): "includeRestingHeartRate",
-            HKQuantityType.quantityType(forIdentifier: .oxygenSaturation): "includeOxygenSaturation",
-            HKQuantityType.quantityType(forIdentifier: .respiratoryRate): "includeRespiratoryRate",
-            HKQuantityType.quantityType(forIdentifier: .walkingHeartRateAverage): "includeWalkingHeartRateAverage"
-        ]
-        var toggleNameToBoolMapping: [String: Bool] = PrivacyModule().getCurrentToggles()
+//        var sampleToToggleNameMapping: [HKQuantityType?: String] = [
+//            HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned): "includeActiveEnergyBurned",
+//            HKQuantityType.quantityType(forIdentifier: .stepCount): "includeStepCountUpload",
+//            HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning): "includeDistanceWalkingRunning",
+//            HKQuantityType.quantityType(forIdentifier: .vo2Max): "includeVo2Max",
+//            HKQuantityType.quantityType(forIdentifier: .heartRate): "includeHeartRate",
+//            HKQuantityType.quantityType(forIdentifier: .restingHeartRate): "includeRestingHeartRate",
+//            HKQuantityType.quantityType(forIdentifier: .oxygenSaturation): "includeOxygenSaturation",
+//            HKQuantityType.quantityType(forIdentifier: .respiratoryRate): "includeRespiratoryRate",
+//            HKQuantityType.quantityType(forIdentifier: .walkingHeartRateAverage): "includeWalkingHeartRateAverage"
+//        ]
+//        var toggleNameToBoolMapping: [String: Bool] = PrivacyModule().getCurrentToggles()
+//        
+//        if let variableName = sampleToToggleNameMapping[quantityType] {
+//            let response: Bool = toggleNameToBoolMapping[variableName] ?? false
+//            
+//            if !response {
+//                return
+//            }
+//        } else {
+//            return
+//        }
         
-        if let variableName = sampleToToggleNameMapping[quantityType] {
-            let response: Bool = toggleNameToBoolMapping[variableName] ?? false
-            
-            if !response {
-                return
-            }
-        } else {
-            return
-        }
-        
-        let path: String
-        
-        // retrieve id of HKSample (e.g. HKQuantityTypeIdentifierStepCount)
-        let identifier = quantityType.identifier
         
         // convert the startDate of the HKSample to local time
-        let effectiveTimestamp = sample.startDate.localISOFormat()
+        let startDatetime = sample.startDate
+        let effectiveTimestamp = startDatetime.localISOFormat()
+        let endDatetime = sample.endDate.localISOFormat()
         
+        let path: String
         // path = HEALTH_KIT_PATH/raw/YYYY-MM-DDThh:mm:ss.mss
         do {
             path = try await getPath(module: .health(identifier)) + "raw/\(effectiveTimestamp)"


### PR DESCRIPTION
# *Adding Sleep and Workout Data*

## :recycle: Current situation & Problem
The current version of the app does not upload sleep data or workout data, both of which are important data sources to include for physical activity behavior change. This PR adds support to query HealthKit for `HKCategoryType(.sleepAnalysis)` and `HKWorkoutType` entries and upload them appropriately to our Firestore database. 


## :gear: Release Notes 
* Updated the query in `PrismaAppDelegate.swift` and added additional functionality in `PrismaStandard+HealthKit.swift` for processing upload paths, which previously only support `HKQuantityType` objects. 


## :books: Documentation
N/A


## :white_check_mark: Testing
N/A

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
