### PR TITLE
Hide Data by Custom Range (New implementation + Bug Fixes)

### DIFF
--- a/Prisma/PrivacyControls/DeleteDataView.swift
+++ b/Prisma/PrivacyControls/DeleteDataView.swift
@@ -100,7 +100,7 @@ struct DeleteDataView: View {
     }
     
     var hideByTimeSection: some View {
-        Section(header: Text("Hide by Timestamps")) {
+        Section(header: Text("Hide Data by Recent Timestamps")) {
             timeStampsDisplay
         }
     }

--- a/Prisma/PrivacyControls/DeleteDataView.swift
+++ b/Prisma/PrivacyControls/DeleteDataView.swift
@@ -77,14 +77,14 @@ struct DeleteDataView: View {
     var hideByCustomRangeSection: some View {
         Section(header: Text("Hide Data by Custom Range")) {
             VStack {
-                DatePicker("Start date", selection: $customHideStartDate, displayedComponents: .date)
-                DatePicker("End date", selection: $customHideEndDate, displayedComponents: .date)
+                DatePicker("Start date", selection: $customHideStartDate, displayedComponents: [.date, .hourAndMinute])
+                DatePicker("End date", selection: $customHideEndDate, displayedComponents: [.date, .hourAndMinute])
                 
                 Divider()
 
                 Button("Hide") {
-                    let startDateString = formatDate(customHideStartDate)
-                    let endDateString = formatDate(customHideEndDate)
+                    let startDateString = customHideStartDate.toISOFormat()
+                    let endDateString = customHideEndDate.toISOFormat()
                     Task {
                         customRangeTimestamps = await standard.fetchCustomRangeTimeStamps(
                             selectedTypeIdentifier: categoryIdentifier,
@@ -119,12 +119,6 @@ struct DeleteDataView: View {
             .foregroundColor(crossedOutTimestamps[timestamp, default: false] ? .gray : .black)
             .opacity(crossedOutTimestamps[timestamp, default: false] ? 0.5 : 1.0)
         }
-    }
-    
-    func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
     }
     
     func switchHiddenInBackend(identifier: String, timestamps: [String], alwaysHide: Bool) {

--- a/Prisma/Resources/Localizable.xcstrings
+++ b/Prisma/Resources/Localizable.xcstrings
@@ -436,16 +436,13 @@
     "Hide" : {
 
     },
-    "Hide by Timestamps" : {
-
-    },
     "Hide Data by Custom Range" : {
 
     },
-    "Hide Timestamp" : {
+    "Hide Data by Recent Timestamps" : {
 
     },
-    "Invalid URL" : {
+    "Hide Timestamp" : {
 
     },
     "Invalid URL" : {

--- a/Prisma/SharedContext/FeatureFlags.swift
+++ b/Prisma/SharedContext/FeatureFlags.swift
@@ -16,7 +16,7 @@ enum FeatureFlags {
     static let disableFirebase = CommandLine.arguments.contains("--disableFirebase")
     #if targetEnvironment(simulator)
     // Defines if the application should connect to the local firebase emulator. Always set to true when using the iOS simulator.
-    static let useFirebaseEmulator = false
+    static let useFirebaseEmulator = true
     #else
     /// Defines if the application should connect to the local firebase emulator. Always set to true when using the iOS simulator.
     static let useFirebaseEmulator = CommandLine.arguments.contains("--useFirebaseEmulator")

--- a/Prisma/SharedContext/FeatureFlags.swift
+++ b/Prisma/SharedContext/FeatureFlags.swift
@@ -14,13 +14,13 @@ enum FeatureFlags {
     static let showOnboarding = CommandLine.arguments.contains("--showOnboarding")
     /// Disables the Firebase interactions, including the login/sign-up step and the Firebase Firestore upload.
     static let disableFirebase = CommandLine.arguments.contains("--disableFirebase")
-    // if targetEnvironment(simulator)
+    #if targetEnvironment(simulator)
     // Defines if the application should connect to the local firebase emulator. Always set to true when using the iOS simulator.
-    // static let useFirebaseEmulator = true
-    // else
+    static let useFirebaseEmulator = false
+    #else
     /// Defines if the application should connect to the local firebase emulator. Always set to true when using the iOS simulator.
     static let useFirebaseEmulator = CommandLine.arguments.contains("--useFirebaseEmulator")
-    // endif
+    #endif
     /// Adds a test task to the schedule at the current time
     static let testSchedule = CommandLine.arguments.contains("--testSchedule")
 }

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -207,16 +207,13 @@ extension PrismaStandard {
             print("Selected identifier: " + selectedTypeIdentifier)
             print("Path from getPath: " + path)
             
-            let querySnapshot = try await firestore.collection(path).getDocuments()
+            let querySnapshot = try await firestore.collection(path)
+                .whereField("issued", isGreaterThanOrEqualTo: startDate)
+                .whereField("issued", isLessThanOrEqualTo: endDate)
+                .getDocuments()
             
             for document in querySnapshot.documents {
-                let documentID = document.documentID
-                let documentDate = String(documentID.prefix(10))
-                
-                // check if documentID date is within the start and end date range
-                if documentDate >= startDate && documentDate <= endDate {
-                    timestampsArr.append(documentID)
-                }
+                timestampsArr.append(document.documentID)
             }
             return timestampsArr
         } catch {

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -80,6 +80,7 @@ extension PrismaStandard {
             // timeIndex is a dictionary with time-related info (range, timezone, datetime.start, datetime.end)
             // timeIndex is added a field for this specific HK datapoint so we can just access this part to fetch/sort by time
             firestoreResource["time"] = timeIndex
+            firestoreResource["datetimeStart"] = timeIndex
             try await Firestore.firestore().document(path).setData(firestoreResource)
         } catch {
             print("Failed to set data in Firestore: \(error.localizedDescription)")
@@ -181,7 +182,7 @@ extension PrismaStandard {
             print("Path from getPath: " + path)
             
             let querySnapshot = try await firestore.collection(path)
-                .order(by: "issued", descending: true)
+                .order(by: "datetimeStart", descending: false)
                 .limit(to: 10)
                 .getDocuments()
 
@@ -208,8 +209,8 @@ extension PrismaStandard {
             print("Path from getPath: " + path)
             
             let querySnapshot = try await firestore.collection(path)
-                .whereField("issued", isGreaterThanOrEqualTo: startDate)
-                .whereField("issued", isLessThanOrEqualTo: endDate)
+                .whereField("datetimeStart", isGreaterThanOrEqualTo: startDate)
+                .whereField("datetimeStart", isLessThanOrEqualTo: endDate)
                 .getDocuments()
             
             for document in querySnapshot.documents {

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -80,7 +80,7 @@ extension PrismaStandard {
             // timeIndex is a dictionary with time-related info (range, timezone, datetime.start, datetime.end)
             // timeIndex is added a field for this specific HK datapoint so we can just access this part to fetch/sort by time
             firestoreResource["time"] = timeIndex
-            firestoreResource["datetimeStart"] = timeIndex
+            firestoreResource["datetimeStart"] = effectiveTimestamp
             try await Firestore.firestore().document(path).setData(firestoreResource)
         } catch {
             print("Failed to set data in Firestore: \(error.localizedDescription)")
@@ -182,7 +182,7 @@ extension PrismaStandard {
             print("Path from getPath: " + path)
             
             let querySnapshot = try await firestore.collection(path)
-                .order(by: "datetimeStart", descending: false)
+                .order(by: "datetimeStart", descending: true)
                 .limit(to: 10)
                 .getDocuments()
 


### PR DESCRIPTION
# Hide Data by Custom Range (New implementation + Bug Fixes)

## :recycle: Current situation & Problem
Currently, in order to hide data by custom range, the function fetchCustomRangeTimeStamps fetches all timestamp documents, then filters for those within the specified time range. However, this means that we have to first fetch all documents which is inefficient and can lower performance. To address this issue, we used .whereField to only fetch documents within the specified time range. Second, we had a problem with accessing “datetimeStart” (accessing the contents of a dictionary field). As a temporary fix, we had to sort timestamps by “issued” time. To address this issue, we created a new field “datetimeStart” so we can directly sort by this field. 


## :gear: Release Notes 
- PrismaStandard+HealthKit
    - Modified fetchCustomRangeTimeStamps() to use .whereField to only fetch and append documents within the specified time range. Changed parameter types in  fetchCustomRangeTimeStamps() from Date to String (ISO format string). 
    - Changed fetch order parameter to “datetimeStart” and to “descending = true.” This allows us to sort by the effective time stamp. We chose to switch to this because sometimes the "issued" time stamp was a month off from the effective time stamp. 
    - We had trouble accessing the “datetime.start” field within the “time” dictionary in each data point so we moved the definition of “datetime.start” outside of the “time” dictionary and labeled it as “datetimeStart.” This happens in the add() function which is called each time a data point is uploaded to Firestore. 
- DeleteDataView
    - Removed need for dateFormatter() function. We can simply use toISOFormat to convert type Date to ISOformat string for checking whether a timestamp document is within the start and end time specified. 


## :books: Documentation
N/A


## :white_check_mark: Testing
- If testing after merge and deployment:
    - In featureFlags.swift, switch set useFirebaseEmulator to false. 
    - Replace the appropriate GoogleService-Info.plist 
    - Erase all content and settings from the simulator device. 
    - Run the app and login using personal account and password (corresponding to account on FireStore)
- If testing before merge and deployment: 
    - Run emulator 
    - Log in using [test@account.com](mailto:test@account.com) and testing123 
    - Manually add “datetimeStart” timestamp fields equal to the documentID timestamp for each timestamp you want to test 
    - Run the app on xcode and input values to hide by custom range.

## :books: Roles
- Evelyn: 
    - Modified fetchCustomRangeTimeStamps() to use .whereField to only fetch timestamp documents within specified range (between startDate and endDate).
    - Modified ISO date/time formatting from date picker to pass into fetchCustomRangeTimeStamps()
- Caroline:
    - Modified the add() function so for each data point uploaded to Firestore, a new field called “datetimeStart” is created. This field is used when fetching and sorting the most recent timestamps. 
    - Modified the fetchTop10RecentTimeStamps() to fetch and order by “datetimeStart” in descending order (most recent data points first, least recent data points last)
Revised section header in DeleteDataView to better represent the section: “Hide Data by Recent Timestamps”


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
