### PR TITLE
Hotfix notification auth for presentation

### DIFF
--- a/Prisma/Home.swift
+++ b/Prisma/Home.swift
@@ -69,7 +69,25 @@ struct HomeView: View {
             }
             .verifyRequiredAccountDetails(Self.accountEnabled)
             .task {
-                await standard.authorizeAccessGroupForCurrentUser()
+                guard let user = Auth.auth().currentUser else {
+                    print("No signed in user.")
+                    return
+                }
+                let accessGroup = "637867499T.edu.stanford.cs342.2024.behavior"
+                
+                guard (try? Auth.auth().getStoredUser(forAccessGroup: accessGroup)) == nil else {
+                    print("Access group already shared ...")
+                    return
+                }
+                
+                do {
+                    try Auth.auth().useUserAccessGroup(accessGroup)
+                    try await Auth.auth().updateCurrentUser(user)
+                } catch let error as NSError {
+                    print("Error changing user access group: %@", error)
+                    // log out the user if fails
+                    try? Auth.auth().signOut()
+                }
             }
     }
 }


### PR DESCRIPTION
# *Notification auth fix for app extension*


## :recycle: Current situation & Problem
Currently for background notifications, we need cross-app authentication and keychain sharing between the main Prisma app and Notification Service Extension, in order to authorize for Firebase. This function was modularized into its own functino within `PrismaStandard`, which unfortunately broke the working auth by making a user log in twice, once during the onboarding and once during the home view. 


## :gear: Release Notes 

As a quick fix, we duplicate the code in both the home view and account onboarding view, which fixes the bug. This is only a quick workaround for the final presentation and SHOULD be modularized into its own function in the Standard eventually.


## :books: Documentation
N/a


## :white_check_mark: Testing
N/A


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
