### PR TITLE
Flatten Time Index

### DIFF
--- a/Prisma/Helper/Date+ConstructTimeIndex.swift
+++ b/Prisma/Helper/Date+ConstructTimeIndex.swift
@@ -21,13 +21,13 @@ extension Date {
         var timeIndex: [String: Any?] = [
             "range": isRange,
             "timezone": startComponents.timeZone?.identifier,
-            "datetime.start": startDate.toISOFormat(),
-            "datetime.end": endDate.toISOFormat()
+            "datetimeStart": startDate.toISOFormat(),
+            "datetimeEnd": endDate.toISOFormat()
         ]
         
         // passing the timeIndex dictionary by reference so the changes persist
-        addTimeIndexComponents(&timeIndex, dateComponents: startComponents, suffix: ".start")
-        addTimeIndexComponents(&timeIndex, dateComponents: endComponents, suffix: ".end")
+        addTimeIndexComponents(&timeIndex, dateComponents: startComponents, suffix: "Start")
+        addTimeIndexComponents(&timeIndex, dateComponents: endComponents, suffix: "End")
         addTimeIndexRangeComponents(&timeIndex, startComponents: startComponents, endComponents: endComponents)
         
         return timeIndex
@@ -54,34 +54,34 @@ extension Date {
         startComponents: DateComponents,
         endComponents: DateComponents
     ) {
-        timeIndex["year.range"] = getRange(
+        timeIndex["yearRange"] = getRange(
             start: startComponents.year,
             end: endComponents.year,
             maxValue: Int.max
         )
-        timeIndex["month.range"] = getRange(
+        timeIndex["monthRange"] = getRange(
             start: startComponents.month,
             end: endComponents.month,
             maxValue: 12,
             startValue: 1 // months are 1-indexed
         )
-        timeIndex["day.range"] = getRange(
+        timeIndex["dayRange"] = getRange(
             start: startComponents.day,
             end: endComponents.day,
             maxValue: daysInMonth(month: startComponents.month, year: startComponents.year),
             startValue: 1 // days are 1-indexed
         )
-        timeIndex["hour.range"] = getRange(
+        timeIndex["hourRange"] = getRange(
             start: startComponents.hour,
             end: endComponents.hour,
             maxValue: 23
         )
-        timeIndex["dayMinute.range"] = getRange(
+        timeIndex["dayMinuteRange"] = getRange(
             start: calculateDayMinute(hour: startComponents.hour, minute: startComponents.minute),
             end: calculateDayMinute(hour: endComponents.hour, minute: endComponents.minute),
             maxValue: 1439
         )
-        timeIndex["fifteenMinBucket.range"] = getRange(
+        timeIndex["fifteenMinBucketRange"] = getRange(
             start: calculate15MinBucket(hour: startComponents.hour, minute: startComponents.minute),
             end: calculate15MinBucket(hour: endComponents.hour, minute: endComponents.minute),
             maxValue: 95

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -49,7 +49,7 @@ extension PrismaStandard: HealthKitConstraint {
             firestoreResource["device"] = deviceName
             // timeIndex is a dictionary with time-related info (range, timezone, datetime.start, datetime.end)
             // timeIndex fields are merged with this specific HK datapoint so we can just access this part to fetch/sort by time
-            firestoreResource.merge(timeIndex as [String : Any]) { (_, new) in new }
+            firestoreResource.merge(timeIndex as [String: Any]) { _, new in new }
             firestoreResource["datetimeStart"] = effectiveTimestamp
             try await Firestore.firestore().document(path).setData(firestoreResource)
         } catch {

--- a/Prisma/Standard/PrismaStandard+HealthKit.swift
+++ b/Prisma/Standard/PrismaStandard+HealthKit.swift
@@ -48,8 +48,8 @@ extension PrismaStandard: HealthKitConstraint {
             var firestoreResource = try encoder.encode(resource)
             firestoreResource["device"] = deviceName
             // timeIndex is a dictionary with time-related info (range, timezone, datetime.start, datetime.end)
-            // timeIndex is added a field for this specific HK datapoint so we can just access this part to fetch/sort by time
-            firestoreResource["time"] = timeIndex
+            // timeIndex fields are merged with this specific HK datapoint so we can just access this part to fetch/sort by time
+            firestoreResource.merge(timeIndex as [String : Any]) { (_, new) in new }
             firestoreResource["datetimeStart"] = effectiveTimestamp
             try await Firestore.firestore().document(path).setData(firestoreResource)
         } catch {


### PR DESCRIPTION
# *Flatten Time Index*

## :recycle: Current situation & Problem
Our current time indexing functionality writes time index entries as nested fields in Firebase, e.g., "time.day.start". For some reason, Firebase fetching (both in Swift and Python) does not play nicely with these nested indices. For example, querying `collection.where("time.day.start", "<=", 10)` returns an empty list. Renaming this field to "dayStart" and avoiding nested fields fixes this issue. 


## :gear: Release Notes 
* Modified `Date+ConstructTimeIndex.swift` to remove nested indices

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
