### PR TITLE
Fix Bug in Workout String Identifier

### DIFF
--- a/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
+++ b/Prisma.xcodeproj/xcshareddata/xcschemes/Prisma.xcscheme
@@ -95,7 +95,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--useFirebaseEmulator"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/Prisma/Helper/String+HealthKitIdentifier.swift
+++ b/Prisma/Helper/String+HealthKitIdentifier.swift
@@ -13,8 +13,8 @@ extension String {
     /// converts a HKSample Type string representation to a lower cased id.
     /// e.g. "HKQuantityTypeIdentifierStepCount" => "stepcount".
     var healthKitDescription: String {
-        if self == "workout" {
-            return self
+        if self == "workout" || self == "HKWorkoutTypeIdentifier" {
+            return "workout"
         }
         
         let prefixes = ["HKQuantityTypeIdentifier", "HKCategoryTypeIdentifier", "HKCorrelationTypeIdentifier", "HKWorkoutTypeIdentifier"]

--- a/Prisma/PrismaDelegate.swift
+++ b/Prisma/PrismaDelegate.swift
@@ -99,7 +99,7 @@ class PrismaDelegate: SpeziAppDelegate {
                 Set(PrismaDelegate.healthKitSampleTypes),
                 /// predicate to request data from one month in the past to present.
                 predicate: HKQuery.predicateForSamples(
-                    withStart: Calendar.current.date(byAdding: .month, value: -1, to: .now),
+                    withStart: Calendar.current.date(byAdding: .month, value: -6, to: .now),
                     end: nil,
                     options: .strictEndDate
                 ),


### PR DESCRIPTION
# *Fix Bug in Workout String Identifier*

## :recycle: Current situation & Problem
A bug in HKWorkout type's HealthKitIdentifier string was resulting in invalid Firebase paths, causing an crash.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
